### PR TITLE
removed IPv6 support because kubernetes does not support it

### DIFF
--- a/caluma-demo/nginx.conf
+++ b/caluma-demo/nginx.conf
@@ -1,6 +1,5 @@
 server {
   listen 80 default_server;
-  listen [::]:80 default_server;
 
   root /usr/share/nginx/html;
 


### PR DESCRIPTION
Kubernetes <1.16 has no IPv6 support. Deactivating it enables us to run nginx in Kubernetes