### PR TITLE
Move proxy_pass to caluma to a variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Publish Docker
 on:
   push:
     branches:
+      - master
       - stable
 jobs:
   build:
@@ -9,11 +10,12 @@ jobs:
     steps:
     - name: checkout branch
       uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+    - name: Publish to Docker Hub
+      uses: docker/build-push-action@v1.1.0
       with:
-        name: projectcaluma/caluma-demo
+        repository: projectcaluma/caluma-demo
+        tag_with_ref: true
+        path: caluma-demo
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        workdir: caluma-demo
         dockerfile: Dockerfile

--- a/caluma-demo/Dockerfile
+++ b/caluma-demo/Dockerfile
@@ -13,10 +13,8 @@ RUN yarn ember deploy production
 FROM nginx:alpine as nginx
 
 COPY --from=frontend /app/tmp/deploy-dist /usr/share/nginx/html
-COPY ./nginx.conf /etc/nginx/conf.d/default.conf.template
-COPY ./docker-entrypoint.sh /
+COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 
 EXPOSE 80
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/caluma-demo/docker-entrypoint.sh
+++ b/caluma-demo/docker-entrypoint.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env sh
-set -eu
-
-envsubst '${BACKEND_HOST} ${BACKEND_PORT}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
-rm /etc/nginx/conf.d/default.conf.template
-
-exec "$@"

--- a/caluma-demo/nginx.conf
+++ b/caluma-demo/nginx.conf
@@ -16,7 +16,8 @@ server {
   }
 
   location ~ ^/graphql/ {
-    proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT};
+    set $caluma http://caluma:8000;
+    proxy_pass $caluma;
   }
 
   location = /index.html {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,8 +24,6 @@ services:
       - caluma
     environment:
       - ENV=development
-      - BACKEND_HOST=caluma
-      - BACKEND_PORT=8000
     ports:
       - "80:80"
 

--- a/kubernetes.yaml
+++ b/kubernetes.yaml
@@ -161,10 +161,6 @@ spec:
         env:
         - name: ENV
           value: development
-        - name: BACKEND_HOST
-          value: caluma
-        - name: BACKEND_PORT
-          value: 8000
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
When running within Kubernetes we're bypassing this with Ingress anyway.